### PR TITLE
epg: allow epg_match_event_fuzzy() to match events on different netwo…

### DIFF
--- a/src/epg.c
+++ b/src/epg.c
@@ -720,7 +720,6 @@ static int epg_match_event_fuzzy(epg_broadcast_t *a, epg_broadcast_t *b)
   if (a->dvb_eid) {
     if (b->dvb_eid && a->dvb_eid == b->dvb_eid)
       return 1;
-    return 0;
   }
 
   /* Wrong length (+/-20%) */


### PR DESCRIPTION
…rks. Fixes #5494

On UK Freeview (DVB-T) and Freesat (DVB-S) events can have different eids for the same channel on the two networks. If a timer is scheduled on one network but the epg is gathered from the other, the eids will not match so a comparison of other parameters is needed to select the correct r/s. This patch removes the short-circuit when eids are present but different.